### PR TITLE
a course with a specific id is only available after a specific date.

### DIFF
--- a/src/pages/Home/Home.test.tsx
+++ b/src/pages/Home/Home.test.tsx
@@ -73,8 +73,8 @@ describe('Test the Home page', () => {
 
     await waitFor(() => {
       const course = getAllByText('components.Home.Button.Course')
-      fireEvent.click(course[1])
-      expect(navigate).toHaveBeenCalledWith('/course/2')
+      fireEvent.click(course[0])
+      expect(navigate).toHaveBeenCalledWith('/course/1')
     })
   })
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -68,6 +68,11 @@ export const Home = () => {
     }
   }, [loading])
 
+  // In the upcoming Evaluation (Nov. 2023) a course is only available after a specific date
+  const courseDateReached = (date: string, courseId: number) : boolean => {
+    return courseId == 2 ? (new Date() <= new Date(date)) : false
+  }
+
   // Card cointaining the courses with a button to the specific course
   return loading ? (
     <Skeleton variant="rectangular" width="100%" height={118} />
@@ -92,6 +97,7 @@ export const Home = () => {
                       <Button
                         variant="contained"
                         color="primary"
+                        disabled={courseDateReached('November 22, 2023 10:00:00', course.id)}
                         onClick={() => {
                           navigate('/course/' + course.id)
                         }}>


### PR DESCRIPTION
## Description

Kempten has 2 Topics, the later one should only be available after a certain date. The courseId and date ist hardcoded.

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [ ] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Requirements
- [ ] Everything build out of Material UI components
- [ ] New Material UI components capsulated via dependency injection in "@common/components"
- [ ] Provide basic information pieces in comments
- [ ] Establish interface to backend (if necessary) 
- [ ] Use Skeleton components if something has to be fetched (if necessary)
- [ ] Error management: Components should handle undefined inputs
- [ ] Components should be resuable (if possible)
- [ ] [Component Requirements](https://lab.las3.de/nextcloud/index.php/apps/onlyoffice/510074?filePath=%2FHASKI-Extern%2F06-Frontend%2F03-UX%2F04-Implementation%2FComponent_Requirements.docx) are met
