### PR TITLE
added variable to moodle url for the new theme version to work

### DIFF
--- a/src/components/IFrameModal/IFrameModal.tsx
+++ b/src/components/IFrameModal/IFrameModal.tsx
@@ -51,10 +51,10 @@ const IFrameModalMemo = (props: IFrameModalProps): JSX.Element => {
           <Close />
         </Fab>
         <iframe
-          src={props.url}
+          src={props.url + '&haski=true'}
           title={props.title}
           width="100%"
-          height="105%"
+          height="104%"
           style={{
             position: 'relative',
             border: 0


### PR DESCRIPTION
## Description

<!--
The new Moodle Theme version needs the variable haski=true in the URL to show the HASKI appropriate view of Moodle. The variable is added in the IFrameModal Component.
"close #262 " 
-->

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [ ] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [x] Other <!-- please specify in the description below -->

## Requirements
- [ ] Everything build out of Material UI components
- [ ] New Material UI components capsulated via dependency injection in "@common/components"
- [ ] Provide basic information pieces in comments
- [ ] Establish interface to backend (if necessary) 
- [ ] Use Skeleton components if something has to be fetched (if necessary)
- [ ] Error management: Components should handle undefined inputs
- [ ] Components should be resuable (if possible)
- [ ] [Component Requirements](https://lab.las3.de/nextcloud/index.php/apps/onlyoffice/510074?filePath=%2FHASKI-Extern%2F06-Frontend%2F03-UX%2F04-Implementation%2FComponent_Requirements.docx) are met
