### PR TITLE
Refactored postCalculateLearningPathILS to only need necessary parameter

### DIFF
--- a/src/components/Questionnaire/QuestionnaireQuestions/Table/Questions.hooks.tsx
+++ b/src/components/Questionnaire/QuestionnaireQuestions/Table/Questions.hooks.tsx
@@ -83,42 +83,23 @@ const useHandleSend = (data: { question_id: string; answer: string }[], ils: boo
   return { sendAnswers, isSending }
 }
 
-//hardcoded courseId, topicId, algorithm for evaluation
-// TODO: the postCalculateLearningPathILS has to be changed. Frontend should only give
-// notice when the calculation should start. What should be calculated should be
-// defined in the backend.
-const courseList = [1]
-const topicList = [2, 6, 10, 12]
-const algorithmList = ['aco', 'graf', 'graf', 'aco']
-
 const calculateLearningPath = (
   user: User,
   addSnackbar: (newSnackbar: SnackbarMessageProps) => void,
   t: (key: string) => string
 ) => {
-  courseList.forEach((courseId) => {
-    topicList.forEach((topicId, index) => {
-      postCalculateLearningPathILS(
-        user.settings.user_id,
-        user.lms_user_id,
-        user.id,
-        courseId,
-        topicId,
-        algorithmList[index]
-      )
-        .then((response) => {
-          log.info(response)
-        })
-        .catch((error) => {
-          addSnackbar({
-            message: t('error.postCalculateLearningPathILS'),
-            severity: 'error',
-            autoHideDuration: 5000
-          })
-          log.error(t('error.postCalculateLearningPathILS') + '' + error)
-        })
+  postCalculateLearningPathILS(user.settings.user_id, user.lms_user_id)
+    .then((response) => {
+      log.info(t('info.postCalculateLearningPathILS') + '' + response)
     })
-  })
+    .catch((error) => {
+      addSnackbar({
+        message: t('error.postCalculateLearningPathILS'),
+        severity: 'success',
+        autoHideDuration: 5000
+      })
+      log.error(t('error.postCalculateLearningPathILS') + '' + error)
+    })
 }
 
 export default useHandleSend

--- a/src/services/LearningPath/postCalculateLearningPathILS.test.tsx
+++ b/src/services/LearningPath/postCalculateLearningPathILS.test.tsx
@@ -1,0 +1,53 @@
+//Tests fail with shortened Path
+import { getConfig } from '@shared'
+import { postCalculateLearningPathILS } from './postCalculateLearningPathILS'
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ status: 200 }),
+    ok: true,
+    headers: {
+      post: () => 'application/json'
+    }
+  })
+) as jest.Mock
+
+describe('postCalculateLearningPathILS tests', () => {
+  it('should return inputData if succesfull', async () => {
+    const inputData = ['1', '1']
+
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue(inputData)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    fetch.mockResolvedValue(mockResponse)
+
+    const result = await postCalculateLearningPathILS(1, 1)
+
+    expect(fetch).toHaveBeenCalledWith(`${getConfig().BACKEND}/user/1/1/learningPath`, {
+      body: '{}',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST'
+    })
+    expect(result).toEqual(inputData)
+  })
+
+  it('should throw an unknown error when the response does not have an error variable', async () => {
+    const mockResponse = {
+      ok: false,
+      json: jest.fn().mockResolvedValue({})
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    fetch.mockResolvedValue(mockResponse)
+
+    await expect(postCalculateLearningPathILS(1, 1)).rejects.toThrow('')
+  })
+})

--- a/src/services/LearningPath/postCalculateLearningPathILS.tsx
+++ b/src/services/LearningPath/postCalculateLearningPathILS.tsx
@@ -10,13 +10,10 @@ import { fetchData } from '../RequestResponse'
   * @param userId - user id
   * @param lmsUserId - lms user id
   * @param studentId - student id
-  * @param courseId - course id
-  * @param topicId - topic id
-  * @param algorithm - algorithm to use, can be: "graf", "aco", "ga"
   *
   * @remarks
   * Sends a request to the backend to calculate the learning path for a student for a course.
-  * Throws an error if userId, lmsUserId, studentId, courseId, topicId or algorithm are not provided.
+  * Throws an error if userId or lmsUserId is not provided.
   *
   * @returns - returns a promise with the learning path
   *
@@ -24,22 +21,14 @@ import { fetchData } from '../RequestResponse'
  */
 export const postCalculateLearningPathILS = async (
   userId?: number,
-  lmsUserId?: number,
-  studentId?: number,
-  courseId?: number,
-  topicId?: number,
-  algorithm?: string
-): Promise<LearningPathBasedOn> => {
-  return fetchData<learningPathBasedOn>(
-    getConfig().BACKEND +
-      `/user/${userId}/${lmsUserId}/student/${studentId}/course/${courseId}/topic/${topicId}/learningPath`,
-    {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ algorithm: algorithm })
-    }
-  )
+  lmsUserId?: number
+): Promise<LearningPathBasedOn[]> => {
+  return fetchData<learningPathBasedOn[]>(getConfig().BACKEND + `/user/${userId}/${lmsUserId}/learningPath`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({})
+  })
 }

--- a/src/shared/translation/translationEnglish.json
+++ b/src/shared/translation/translationEnglish.json
@@ -1156,6 +1156,7 @@
   "error.setTopics": "There was an Error setting Topics.",
   "error.setTopicsPath": "There was an Error setting Topics Path.",
   "info": "Info",
+  "info.postCalculateLearningPathILS": "A POST request was successfully sent to calculate the learning path based on the ILS questionnaire data.",
   "log.learningPathTopicProgressTimeout": "A timeout occured while loading the LearningPathTopicProgress hook.",
   "pages.1": "1",
   "pages.10": "10",

--- a/src/shared/translation/translationGerman.json
+++ b/src/shared/translation/translationGerman.json
@@ -1156,6 +1156,7 @@
   "error.setTopics": "Es gab einen Fehler beim Festlegen der Themen.",
   "error.setTopicsPath": "Es gab einen Fehler beim Festlegen des Themenpfads.",
   "info": "Info",
+  "info.postCalculateLearningPathILS": "Eine POST-Anfrage wurde erfolgreich gesendet, um den Lernpfad auf der Grundlage der Daten des ILS-Fragebogens zu berechnen.",
   "log.learningPathTopicProgressTimeout": "Beim Laden des LearningPathTopicProgress-Hook ist ein Timout aufgetreten.",
   "pages.1": "1",
   "pages.10": "10",


### PR DESCRIPTION
Refactored postCalculateLearningPathILS to only need user_id and lms_user_id as params
Tested postCalculateLearningPathILS
Added translation for log.info

## Description

<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [x] Refactoring <!-- code style changes, refactoring, etc. -->
- [x] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Requirements
- [x] Everything build out of Material UI components
- [x] New Material UI components capsulated via dependency injection in "@common/components"
- [x] Provide basic information pieces in comments
- [x] Establish interface to backend (if necessary) 
- [x] Use Skeleton components if something has to be fetched (if necessary)
- [x] Error management: Components should handle undefined inputs
- [x] Components should be resuable (if possible)
- [x] [Component Requirements](https://lab.las3.de/nextcloud/index.php/apps/onlyoffice/510074?filePath=%2FHASKI-Extern%2F06-Frontend%2F03-UX%2F04-Implementation%2FComponent_Requirements.docx) are met
