### PR TITLE
fetch new learning paths when user navigates to another topic

### DIFF
--- a/src/pages/Topic/Topic.tsx
+++ b/src/pages/Topic/Topic.tsx
@@ -51,6 +51,7 @@ export const Topic = ({ useTopic = _useTopic }: TopicProps): JSX.Element => {
   const setLearningPathElementSpecificStatus = usePersistedStore((state) => state.setLearningPathElementStatus)
 
   const learningPathElementCache = useStore((state) => state._cache_learningPathElement_record)
+  const clearLearningPathElementCache = useStore((state) => state.clearLearningPathElementCache)
   const learningPathLearningElementStatusCache = usePersistedStore((state) => state._learningPathElementStatus)
 
   const { url, title, lmsId, isOpen, handleClose, mapNodes } = useTopic()
@@ -94,10 +95,6 @@ export const Topic = ({ useTopic = _useTopic }: TopicProps): JSX.Element => {
         handleError(t, addSnackbar, 'error.mapNodes', error, 3000)
       })
   }
-
-  // Effect to handle the fitting of the view when the topic changes with the LocalNav
-  // [handleCustomFitView] as dependency because inside of it the fitViewButton changes,
-  // that way the reactFlow background is changed before rendering it in a old position from the prev. topic
 
   // Get status of every learning element for user by request to backend
   // then get every learning element for topic by request to backend
@@ -154,6 +151,10 @@ export const Topic = ({ useTopic = _useTopic }: TopicProps): JSX.Element => {
       }, 100)
     }
   }, [initialNodes, navigate, hasCentered])
+
+  useEffect(() => {
+    clearLearningPathElementCache()
+  }, [navigate])
 
   /**
    * Update the learning path element status for the user after he closes a learning Element (iframe)


### PR DESCRIPTION
## Description

Get learning path from backend after user navigates to another topic. Frontend gets the most updated learning path.

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [ ] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Requirements
- [ ] Everything build out of Material UI components
- [ ] New Material UI components capsulated via dependency injection in "@common/components"
- [ ] Provide basic information pieces in comments
- [ ] Establish interface to backend (if necessary) 
- [ ] Use Skeleton components if something has to be fetched (if necessary)
- [ ] Error management: Components should handle undefined inputs
- [ ] Components should be resuable (if possible)
- [ ] [Component Requirements](https://lab.las3.de/nextcloud/index.php/apps/onlyoffice/510074?filePath=%2FHASKI-Extern%2F06-Frontend%2F03-UX%2F04-Implementation%2FComponent_Requirements.docx) are met
