### PR TITLE
Update .gitignore to include jest results and add .gitkeep for reports directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn-error.log
 docs
 wiki
 debug.log
+reports/jest-results.json

--- a/reports/.gitkeep
+++ b/reports/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the reports directory in git so jest --outputFile has a path.


### PR DESCRIPTION
## Description

Added reports folder to store the jest output for generating reports. They are used by the requirements repository.
we need to create and keep this folder since generating reports with no folder results in an ENOF error since jest cant create folders on the fly.

## Type of changes

- [X] CI/CD 